### PR TITLE
Use ALTER TYPE in rename_value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-16.04
     services:
       db:
-        image: postgres:9.6-alpine
+        image: postgres:10.14-alpine
         ports: ['5432:5432']
         env:
           POSTGRES_USER: ecto_enum

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The package can be installed by adding `ecto_enum_migration` to your list of dep
 ```elixir
 def deps do
   [
-    {:ecto_enum_migration, "~> 0.3.0"}
+    {:ecto_enum_migration, "~> 0.3.1"}
   ]
 end
 ```

--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -219,19 +219,11 @@ defmodule EctoEnumMigration do
     after_value = to_value(after_value)
 
     up_sql = "
-      UPDATE pg_catalog.pg_enum
-      SET enumlabel = #{after_value}
-      WHERE enumtypid = '#{type_name}'::regtype::oid
-        AND enumlabel = #{before_value}
-      RETURNING enumlabel;
+      ALTER TYPE #{type_name} RENAME VALUE #{before_value} TO #{after_value};
     "
 
     down_sql = "
-      UPDATE pg_catalog.pg_enum
-      SET enumlabel = #{before_value}
-      WHERE enumtypid = '#{type_name}'::regtype::oid
-        AND enumlabel = #{after_value}
-      RETURNING enumlabel;
+      ALTER TYPE #{type_name} RENAME VALUE #{after_value} TO #{before_value};
     "
 
     execute(up_sql, down_sql)

--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -184,6 +184,8 @@ defmodule EctoEnumMigration do
   @doc """
   Rename a value of a Postgres Type.
 
+  ***Only compatible with Postgres version 10+***
+
   ## Examples
 
   ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoEnumMigration.MixProject do
   def project do
     [
       app: :ecto_enum_migration,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
### Motivation

The previews implementation of the `rename_value` function demanded special permission in order to alter the `pg_catalog.pg_enum` table. Albeit this is fine in localhost, it's an issue in production.

### Proposed solution

Change the function implementation in order to use the `ALTER TYPE` available from Postgres 10 onwards and drop the compatibility with previews versions.