### PR TITLE
feat: Support no-op `down` migrations on `drop_type(..., if_exists: true)` and `add_value_to_type(..., if_not_exists: true)`

### DIFF
--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -71,16 +71,35 @@ defmodule EctoEnumMigration do
   drop_type(:status, schema: "custom_schema")
   ```
 
+  When combined with `if_exists: true`, you can pass `down: :noop` to make the
+  migration reversible with a `down` step that does nothing. This is useful in `change/0`
+  callbacks, where Ecto would otherwise raise on rollback. `down: :noop` requires
+  `if_exists: true`, since re-applying the migration would fail if the type no longer
+  exists.
+
+  ```elixir
+  drop_type(:status, if_exists: true, down: :noop)
+  ```
+
   """
   @spec drop_type(name :: atom(), opts :: Keyword.t()) :: :ok | no_return()
   def drop_type(name, opts \\ []) when is_atom(name) and is_list(opts) do
-    [
-      "DROP TYPE",
-      if_exists_sql(opts),
-      type_name(name, opts),
-      ";"
-    ]
-    |> execute_query()
+    validate_noop_down!(opts, "drop_type/2", :if_exists)
+
+    up_sql =
+      [
+        "DROP TYPE",
+        if_exists_sql(opts),
+        type_name(name, opts),
+        ";"
+      ]
+      |> build_query()
+
+    if Keyword.get(opts, :down) == :noop do
+      execute(up_sql, fn -> :ok end)
+    else
+      execute(up_sql)
+    end
   end
 
   @doc """
@@ -189,7 +208,7 @@ defmodule EctoEnumMigration do
           :ok | no_return()
 
   def add_value_to_type(name, value, opts \\ []) do
-    validate_opts!(opts)
+    validate_noop_down!(opts, "add_value_to_type/3", :if_not_exists)
 
     up_sql =
       [
@@ -307,8 +326,6 @@ defmodule EctoEnumMigration do
     end
   end
 
-  defp execute_query(terms), do: terms |> build_query() |> execute()
-
   defp build_query(terms) do
     terms
     |> Enum.reject(&(is_nil(&1) || &1 == []))
@@ -316,10 +333,10 @@ defmodule EctoEnumMigration do
     |> IO.iodata_to_binary()
   end
 
-  defp validate_opts!(opts) do
-    if opts[:down] == :noop and !opts[:if_not_exists] do
+  defp validate_noop_down!(opts, fun, required_opt) do
+    if opts[:down] == :noop and !opts[required_opt] do
       raise ArgumentError,
-            "add_value_to_type/3 requires `if_not_exists: true` when `down: :noop` is given, " <>
+            "#{fun} requires `#{required_opt}: true` when `down: :noop` is given, " <>
               "otherwise the migration could not be re-applied after a rollback."
     end
   end

--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -184,13 +184,12 @@ defmodule EctoEnumMigration do
   ```elixir
   add_value_to_type(:status, :finished, if_not_exists: true, down: :noop)
   ```
-
   """
   @spec add_value_to_type(name :: atom(), value :: atom(), opts :: Keyword.t()) ::
           :ok | no_return()
 
   def add_value_to_type(name, value, opts \\ []) do
-    validate_down_noop!(opts)
+    validate_opts!(opts)
 
     up_sql =
       [
@@ -317,8 +316,8 @@ defmodule EctoEnumMigration do
     |> IO.iodata_to_binary()
   end
 
-  defp validate_down_noop!(opts) do
-    if Keyword.get(opts, :down) == :noop and not Keyword.get(opts, :if_not_exists, false) do
+  defp validate_opts!(opts) do
+    if opts[:down] == :noop and !opts[:if_not_exists] do
       raise ArgumentError,
             "add_value_to_type/3 requires `if_not_exists: true` when `down: :noop` is given, " <>
               "otherwise the migration could not be re-applied after a rollback."

--- a/lib/ecto_enum_migration.ex
+++ b/lib/ecto_enum_migration.ex
@@ -175,21 +175,40 @@ defmodule EctoEnumMigration do
   add_value_to_type(:status, :finished, if_not_exists: true)
   ```
 
+  When combined with `if_not_exists: true`, you can pass `down: :noop` to make the
+  migration reversible with a `down` step that does nothing. This is useful in `change/0`
+  callbacks, where Ecto would otherwise raise on rollback. `down: :noop` requires
+  `if_not_exists: true`, since re-applying the migration would fail if the value already
+  exists.
+
+  ```elixir
+  add_value_to_type(:status, :finished, if_not_exists: true, down: :noop)
+  ```
+
   """
   @spec add_value_to_type(name :: atom(), value :: atom(), opts :: Keyword.t()) ::
           :ok | no_return()
 
   def add_value_to_type(name, value, opts \\ []) do
-    [
-      "ALTER TYPE",
-      type_name(name, opts),
-      "ADD VALUE",
-      if_not_exists_sql(opts),
-      to_value(value),
-      before_after(opts),
-      ";"
-    ]
-    |> execute_query()
+    validate_down_noop!(opts)
+
+    up_sql =
+      [
+        "ALTER TYPE",
+        type_name(name, opts),
+        "ADD VALUE",
+        if_not_exists_sql(opts),
+        to_value(value),
+        before_after(opts),
+        ";"
+      ]
+      |> build_query()
+
+    if Keyword.get(opts, :down) == :noop do
+      execute(up_sql, fn -> :ok end)
+    else
+      execute(up_sql)
+    end
   end
 
   @doc """
@@ -289,11 +308,20 @@ defmodule EctoEnumMigration do
     end
   end
 
-  defp execute_query(terms) do
+  defp execute_query(terms), do: terms |> build_query() |> execute()
+
+  defp build_query(terms) do
     terms
     |> Enum.reject(&(is_nil(&1) || &1 == []))
     |> Enum.intersperse(?\s)
     |> IO.iodata_to_binary()
-    |> execute()
+  end
+
+  defp validate_down_noop!(opts) do
+    if Keyword.get(opts, :down) == :noop and not Keyword.get(opts, :if_not_exists, false) do
+      raise ArgumentError,
+            "add_value_to_type/3 requires `if_not_exists: true` when `down: :noop` is given, " <>
+              "otherwise the migration could not be re-applied after a rollback."
+    end
   end
 end

--- a/test/ecto_enum_migration_test.exs
+++ b/test/ecto_enum_migration_test.exs
@@ -58,6 +58,24 @@ defmodule EctoEnumMigrationTest do
     end
   end
 
+  defmodule DropTypeIfExistsNoopDownMigration do
+    use Ecto.Migration
+    import EctoEnumMigration
+
+    def change do
+      drop_type(:status, if_exists: true, down: :noop)
+    end
+  end
+
+  defmodule DropTypeNoopDownWithoutIfExistsMigration do
+    use Ecto.Migration
+    import EctoEnumMigration
+
+    def change do
+      drop_type(:status, down: :noop)
+    end
+  end
+
   defmodule RenameTypeMigration do
     use Ecto.Migration
     import EctoEnumMigration
@@ -269,6 +287,35 @@ defmodule EctoEnumMigrationTest do
 
       assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
         :ok = down(num, DropTypeIfExistsMigration)
+      end
+    end
+
+    test "supports if exists with down: :noop (reversible no-op down)" do
+      create_version = version_number()
+      drop_version = version_number()
+
+      :ok = up(create_version, CreateTypeMigration)
+      :ok = up(drop_version, DropTypeIfExistsNoopDownMigration)
+
+      assert current_types() == %{}
+
+      :ok = down(drop_version, DropTypeIfExistsNoopDownMigration)
+
+      assert current_types() == %{}
+
+      :ok = up(drop_version, DropTypeIfExistsNoopDownMigration)
+
+      assert current_types() == %{}
+    end
+
+    test "raises when down: :noop is given without if_exists: true" do
+      create_version = version_number()
+      drop_version = version_number()
+
+      :ok = up(create_version, CreateTypeMigration)
+
+      assert_raise ArgumentError, ~r/requires `if_exists: true`/, fn ->
+        up(drop_version, DropTypeNoopDownWithoutIfExistsMigration)
       end
     end
   end

--- a/test/ecto_enum_migration_test.exs
+++ b/test/ecto_enum_migration_test.exs
@@ -114,6 +114,26 @@ defmodule EctoEnumMigrationTest do
     end
   end
 
+  defmodule AddValueToTypeIfNotExistsNoopDownMigration do
+    use Ecto.Migration
+    import EctoEnumMigration
+    @disable_ddl_transaction true
+
+    def change do
+      add_value_to_type(:status, :finished, if_not_exists: true, down: :noop)
+    end
+  end
+
+  defmodule AddValueToTypeNoopDownWithoutIfNotExistsMigration do
+    use Ecto.Migration
+    import EctoEnumMigration
+    @disable_ddl_transaction true
+
+    def change do
+      add_value_to_type(:status, :finished, down: :noop)
+    end
+  end
+
   defmodule AddValueToTypeWithCustomSchemaMigration do
     use Ecto.Migration
     import EctoEnumMigration
@@ -321,6 +341,41 @@ defmodule EctoEnumMigrationTest do
 
       assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
         :ok = down(add_value_version, AddValueToTypeIfNotExistsMigration)
+      end
+    end
+
+    test "supports if not exists with down: :noop (reversible no-op down)" do
+      create_version = version_number()
+      add_value_version = version_number()
+
+      :ok = up(create_version, CreateTypeMigration)
+      :ok = up(add_value_version, AddValueToTypeIfNotExistsNoopDownMigration)
+
+      assert current_types() == %{
+               "public.status" => ["registered", "active", "inactive", "archived", "finished"]
+             }
+
+      :ok = down(add_value_version, AddValueToTypeIfNotExistsNoopDownMigration)
+
+      assert current_types() == %{
+               "public.status" => ["registered", "active", "inactive", "archived", "finished"]
+             }
+
+      :ok = up(add_value_version, AddValueToTypeIfNotExistsNoopDownMigration)
+
+      assert current_types() == %{
+               "public.status" => ["registered", "active", "inactive", "archived", "finished"]
+             }
+    end
+
+    test "raises when down: :noop is given without if_not_exists: true" do
+      create_version = version_number()
+      add_value_version = version_number()
+
+      :ok = up(create_version, CreateTypeMigration)
+
+      assert_raise ArgumentError, ~r/requires `if_not_exists: true`/, fn ->
+        up(add_value_version, AddValueToTypeNoopDownWithoutIfNotExistsMigration)
       end
     end
 


### PR DESCRIPTION
This allows callers to opt-in to a no-op `down` migration when writing an add-value-if-not-exists or drop-type-if-exists migration.

While it isn't burdensome to write your own no-op phase when your migration contains only the enum changes, it does become painful (and error prone) if you're trying to modify an enum _plus_ do something else (say, add a column to a table). In those cases, it's much safer to rely on `change` to use Ecto's built-in reversibility rather than trying to write an explicit `down`. This change makes it so that `add_value_to_type` and `drop_type` _can_ be used within `change` without breaking the reversibility of the migration as a whole.

(You could argue that a no-op `down` is not a true reversal of add-value-if-not-exists, since it doesn't take into account whether the value actually existed when `up` was applied. While that's correct in the most stringent sense, in practice, this _is_ the `down` migration we would always write by hand.)